### PR TITLE
Update required metadata text to say blue instead of green

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -8,7 +8,7 @@ nav_order: 5
 
 Q: What do we need to do to copy data to the DCC?
 
-A: Contact your center liaison so we understand your specific needs, upload your release-ready data with a descriptive top-level folder name, and iteratively annotate and validate your data as new metadata standards are released by the working groups with the [Data Curator App](https://www.synapse.org/#!Wiki:syn20681266/ENTITY)] or the API. Details on how to upload your data can be found in the [Step 1 - Upload Your Data](step-1) section of these docs.     
+A: Contact your center liaison so we understand your specific needs, upload your release-ready data with a descriptive top-level folder name, and iteratively annotate and validate your data as new metadata standards are released by the working groups with the [Data Curator App](https://www.synapse.org/#!Wiki:syn20681266/ENTITY) or the API. Details on how to upload your data can be found in the [Step 1 - Upload Your Data](step-1) section of these docs.     
 
 <br/>
 
@@ -183,7 +183,7 @@ Q: Should large imaging files be compressed?
 
 A: Yes, please compress larger files. The DCC accepts most file compression types, though lossless compression formats such as LZW are preferred.
 
-</br>
+<br/>
 
 ## Data User
 

--- a/step-3.md
+++ b/step-3.md
@@ -26,7 +26,7 @@ Continuing on from [Step 2 - Request a Metadata Template](step-2), you can annot
     
     ![htan-metadata-template](https://user-images.githubusercontent.com/12868382/86075189-4c5a1e80-ba3c-11ea-9e5f-1b2bc797da2d.png)
 
-3. **Required** metadata is highlighted in light green, whereas optional values are in yellow. _Conditionally required_ elements can also appear as you fill out the template.  
+3. **Required** metadata is highlighted in light blue, whereas optional values are in yellow. _Conditionally required_ elements can also appear as you fill out the template.  
 
     ![htan-metadata-optional-required](https://user-images.githubusercontent.com/12868382/86075192-4e23e200-ba3c-11ea-9d31-e6da928624a4.png)
 


### PR DESCRIPTION
Addresses issue: https://github.com/Sage-Bionetworks/HTAN-coordination/issues/243

Also found a typo in a bracket and one of the `<br/>` in the FAQ, so fixed that too. 