### PR TITLE
Update dcc-liaison contact table

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -189,4 +189,4 @@ A: Yes, please compress larger files. The DCC accepts most file compression type
 
 Q: When can we expect a public release of data?
 
-A:  Late fall/early winter 2020, depending on data availability.
+A:  Late spring/early summer 2021, depending on data availability.


### PR DESCRIPTION
This PR updates the image to note Ino as the DCC Liaison for CHOP, Duke, and MSK. Also some stylistic changes to the table for easier readability. 

<img width="771" alt="Screen Shot 2021-07-01 at 1 59 10 PM" src="https://user-images.githubusercontent.com/12868382/124188757-8bb6b300-da74-11eb-937c-2fe65e48a8e5.png">
